### PR TITLE
normalize `aarch64` to `arm64`

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,6 +43,11 @@ get_arch() {
 		return
 	fi
 
+	if [[ "$machine" =~ "aarch64" ]]; then
+		echo "arm64"
+		return
+	fi
+
 	echo $machine
 }
 


### PR DESCRIPTION
Fixes ARM64 support for platforms where `uname -m` yields `aarch64`.